### PR TITLE
Change Spotify.get arg "url" to be positional

### DIFF
--- a/spotiphile/spotiphile.py
+++ b/spotiphile/spotiphile.py
@@ -14,7 +14,7 @@ class Spotiphile:
         self.YOUTUBE_DEV_KEY = YOUTUBE_DEV_KEY
 
     def get(
-        self, url=None, yt_url=None,
+        self, url, yt_url,
         out="Downloads/{artist}/{album}/{title}.mp3"
     ):
 

--- a/spotiphile/spotiphile.py
+++ b/spotiphile/spotiphile.py
@@ -14,7 +14,7 @@ class Spotiphile:
         self.YOUTUBE_DEV_KEY = YOUTUBE_DEV_KEY
 
     def get(
-        self, url, yt_url,
+        self, url, yt_url=None,
         out="Downloads/{artist}/{album}/{title}.mp3"
     ):
 


### PR DESCRIPTION
Since the method does not allow for `url` to be None, it makes no sense to set it as an optional kwarg as `url=None`.

Requiring it as a positional arg forces anyone using the class to provide a url when calling the method. If they provide `None`, then there's still a check that raises an exception.